### PR TITLE
Remove unicode no-break-space.

### DIFF
--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -65,7 +65,7 @@ module EsDumpRestore
       begin
         response = @httpclient.request(method, request_uri, options)
         unless response.ok? or extra_allowed_exitcodes.include? response.status
-          raise "Request failed with status #{response.status}: #{response.reason}"
+          raise "Request failed with status #{response.status}: #{response.reason}"
         end
         MultiJson.load(response.content)
       rescue Exception => e


### PR DESCRIPTION
The first space in this string was actually "\u00A0" ([NO-BREAK-SPACE](http://www.fileformat.info/info/unicode/char/00a0/index.htm)) (introduced in dbc9f931).

This was causing load errors on older versions of ruby eg:

```
/usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require':
/var/lib/gems/1.9.1/gems/es_dump_restore-0.0.10/lib/es_dump_restore/es_client.rb:68:
invalid multibyte char (US-ASCII) (SyntaxError)
/var/lib/gems/1.9.1/gems/es_dump_restore-0.0.10/lib/es_dump_restore/es_client.rb:68:
invalid multibyte char (US-ASCII)
/var/lib/gems/1.9.1/gems/es_dump_restore-0.0.10/lib/es_dump_restore/es_client.rb:68:
syntax error, unexpected $end, expecting keyword_end
          raise "Request failed with status #{response...
```