### PR TITLE
Fix some problems with dumping

### DIFF
--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -42,6 +42,7 @@ module EsDumpRestore
     end
 
     def each_scroll_hit(scroll_id, &block)
+      done = 0
       loop do
         batch = request(:get, '_search/scroll', {query: {
           scroll: '10m', scroll_id: scroll_id
@@ -55,6 +56,10 @@ module EsDumpRestore
         hits.each do |hit|
           yield hit
         end
+
+        total = batch_hits["total"]
+        done += hits.size
+        break if done >= total
       end
     end
 

--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -16,11 +16,19 @@ module EsDumpRestore
     end
 
     def mappings
-      request(:get, "#{@path_prefix}/_mapping")[index_name]
+      data = request(:get, "#{@path_prefix}/_mapping")
+      if data.values.size != 1 || data.values.first["mappings"].nil?
+        raise "Unexpected response: #{data}"
+      end
+      data.values.first["mappings"]
     end
 
     def settings
-      request(:get, "#{@path_prefix}/_settings")[index_name]
+      data = request(:get, "#{@path_prefix}/_settings")
+      if data.values.size != 1 || data.values.first["settings"].nil?
+        raise "Unexpected response: #{data}"
+      end
+      data.values.first["settings"]
     end
 
     def start_scan(&block)


### PR DESCRIPTION
This PR fixes two problems we've experienced with dumping and restoring elasticsearch indexes.

Firstly, we address all our indices via aliases (with one alias per index). This allows us to swap indexes over without any downtime, by changing the alias settings.  If `es_dump_restore dump` is called with an index name which is actually an alias, the dump appears to work successfully, but the "index.json" file in the dump has `nil` for both the `settings` and `mappings`.

Secondly, when restoring data, recent elasticsearch versions appear to forget the scroll context at the end of the iteration through the results.  This triggers an exception at the end of the iteration, with elasticsearch complaining:

```SearchContextMissingException[No search context found for id [....]];```

Instead of relying on elasticsearch remembering the scroll id after the last chunk has been returned, track the count of hits received, and terminate when that reaches the total (as described in each chunk).  This gives identical results for all the tests I've run, but doesn't give errors.