### PR TITLE
Handle elasticsearch 0.90.x response for mappings and settings

### DIFF
--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -17,18 +17,28 @@ module EsDumpRestore
 
     def mappings
       data = request(:get, "#{@path_prefix}/_mapping")
-      if data.values.size != 1 || data.values.first["mappings"].nil?
+      if data.values.size != 1
         raise "Unexpected response: #{data}"
       end
-      data.values.first["mappings"]
+      mappings = data.values.first
+      if mappings["mappings"].nil?
+        mappings
+      else
+        mappings["mappings"]
+      end
     end
 
     def settings
       data = request(:get, "#{@path_prefix}/_settings")
-      if data.values.size != 1 || data.values.first["settings"].nil?
+      if data.values.size != 1
         raise "Unexpected response: #{data}"
       end
-      data.values.first["settings"]
+      settings = data.values.first
+      if settings["settings"].nil?
+        settings
+      else
+        settings["settings"]
+      end
     end
 
     def start_scan(&block)


### PR DESCRIPTION
It turns out that my recent fix breaks dumping indexes from elasticsarch 0.90.x.

Old versions of elasticsearch return the mappings and settings directly
in response to a request to _mappings and _settings, instead of wrapping
them in an object.

Handle this by, if the top level key isn't mappings or settings, just returning the
contents directly.