### PR TITLE
Alias support

### DIFF
--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -75,5 +75,23 @@ module EsDumpRestore
       end
     end
 
+    desc "restore_alias URL ALIAS_NAME INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index, and then sets the alias to point at that index, removing any existing indexes pointed at by the alias"
+    def restore_alias(url, alias_name, index_name, filename)
+      client = EsClient.new(url, index_name, nil)
+      client.check_alias alias_name
+
+      Dumpfile.read(filename) do |dumpfile|
+        client.create_index(dumpfile.index)
+
+        bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
+        dumpfile.scan_objects(1000) do |batch, size|
+          client.bulk_index batch
+          bar.increment!(size) unless options[:noprogressbar]
+        end
+      end
+
+      client.replace_alias_and_close_old_index alias_name
+    end
+
   end
 end

--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -74,11 +74,11 @@ module EsDumpRestore
     end
 
     def create_index(metadata)
-      request(:post, "", :body => MultiJson.dump(metadata))
+      request(:post, "#{@path_prefix}", :body => MultiJson.dump(metadata))
     end
 
     def bulk_index(data)
-      request(:post, "_bulk", :body => data)
+      request(:post, "#{@path_prefix}/_bulk", :body => data)
     end
 
     private

--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -88,12 +88,11 @@ module EsDumpRestore
       begin
         response = @httpclient.request(method, request_uri, options)
         unless response.ok? or extra_allowed_exitcodes.include? response.status
-          raise "Request failed with status #{response.status}: #{response.reason}"
+          raise "Request failed with status #{response.status}: #{response.reason} #{response.content}"
         end
         MultiJson.load(response.content)
       rescue Exception => e
         puts "Exception caught issuing HTTP request to #{request_uri}"
-        puts "options: #{options}"
         raise e
       end
     end

--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -77,6 +77,45 @@ module EsDumpRestore
       request(:post, "#{@path_prefix}", :body => MultiJson.dump(metadata))
     end
 
+    def check_alias(alias_name)
+      # Checks that it's possible to do an atomic restore using the given alias
+      # name.  This requires that:
+      #  - `alias_name` doesn't point to an existing index
+      #  - `index_name` doesn't point to an existing index
+      existing = request(:get, "_aliases")
+      if existing.include? index_name
+        raise "There is already an index called #{index_name}"
+      end
+      if existing.include? alias_name
+        raise "There is already an index called #{alias_name}"
+      end
+    end
+
+    def replace_alias_and_close_old_index(alias_name)
+      existing = request(:get, "_aliases")
+
+      # Response of the form:
+      #   { "index_name" => { "aliases" => { "a1" => {}, "a2" => {} } } }
+      old_aliased_indices = existing.select { |name, details|
+        details.fetch("aliases", {}).keys.include? alias_name
+      }
+      old_aliased_indices = old_aliased_indices.keys
+
+      # For any existing indices with this alias, remove the alias
+      # We would normally expect 0 or 1 such index, but several is
+      # valid too
+      actions = old_aliased_indices.map { |old_index_name|
+        { "remove" => { "index" => old_index_name, "alias" => alias_name } }
+      }
+
+      actions << { "add" => { "index" => index_name, "alias" => alias_name } }
+
+      request(:post, "_aliases", :body => MultiJson.dump({ "actions" => actions }))
+      old_aliased_indices.each do |old_index_name|
+        request(:post, "#{old_index_name}/_close")
+      end
+    end
+
     def bulk_index(data)
       request(:post, "#{@path_prefix}/_bulk", :body => data)
     end


### PR DESCRIPTION
Adds a `restore_alias` command, for loading data in, and then switching an alias to point to it.

The `restore_alias` command functions similarly to the
`restore` command, but takes an additional `alias_name` parameter.
After the index has been uploaded to elasticsearch, any indexes which
were being addressed by the alias have the alias removed, the newly
uploaded index has the alias added, and finally any indexes which
were being addressed by the alias are closed.

This means that applications can perform searches by addressing the
index using the alias name, and from their point of view the uploaded
index replaces the old index atomically.

Also, fix a bug preventing restoring an index using the standard `restore` command.
The index name wasn't being passed to elasticsearch when creating or
uploading data, so it wasn't possible to restore an index.
(Elasticsearch would produce an error complaining about an invalid POST
to '/' - reproduced on elasticsearch 1.4.4.  This worked in relase 0.7, but I'm not sure when it got broken.)

Finally, also display the response body from elasticsearch when an error status code is returned: otherwise, it can be very hard to tell what's wrong.