### PR TITLE
Add option to override settings when loading data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,30 @@ To dump an ElasticSearch index by type to a file:
 
 To restore an index to an ElasticSearch server:
 
-    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATON_INDEX FILENAME_ZIP
+    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES]
+
+To restore an index and set an alias to point to it:
+
+    es_dump_restore restore_alias ELASTIC_SEARCH_SERVER_URL DESTINATION_ALIAS DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES]
+
+This loads the dump into an index named `DESTINATION_INDEX`, and once the load
+is complete sets the alias `DESTINATION_ALIAS` to point to it.  If
+`DESTINATION_ALIAS` already exists, it will be atomically changed to point to
+the new location.  This allows a dump file to be loaded on a running server
+without disrupting searches going on on that server (as long as those searches
+are accessing the index via the alias).
+
+If `SETTING_OVERRIDES` is set for a restore command, it must be a valid
+serialised JSON object.  This will be merged with the settings in the dump
+file, allowing selected settings to be altered, but keeping any unspecified
+settings as they were in the dump file.  For example:
+
+    es_dump_restore restore_alias http://localhost:9200 test test-1276512 test_dump.zip '{"settings":{"index":{"number_of_replicas":"0","number_of_shards":"1"}}'
+
+would read the dump file `test_dump.zip`, load it into an index called
+`test-1276512`, then set the alias `test` to point to this index.  The index
+would be set to have no replicas, and only 1 shard, but have all other settings
+from the dump file.
 
 ## Contributing
 

--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -61,11 +61,11 @@ module EsDumpRestore
     end
 
     desc "restore URL INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index"
-    def restore(url, index_name, filename)
+    def restore(url, index_name, filename, overrides=nil)
       client = EsClient.new(url, index_name, nil)
 
       Dumpfile.read(filename) do |dumpfile|
-        client.create_index(dumpfile.index)
+        client.create_index(dumpfile.index, overrides)
 
         bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
         dumpfile.scan_objects(1000) do |batch, size|
@@ -76,12 +76,12 @@ module EsDumpRestore
     end
 
     desc "restore_alias URL ALIAS_NAME INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index, and then sets the alias to point at that index, removing any existing indexes pointed at by the alias"
-    def restore_alias(url, alias_name, index_name, filename)
+    def restore_alias(url, alias_name, index_name, filename, overrides=nil)
       client = EsClient.new(url, index_name, nil)
       client.check_alias alias_name
 
       Dumpfile.read(filename) do |dumpfile|
-        client.create_index(dumpfile.index)
+        client.create_index(dumpfile.index, overrides)
 
         bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
         dumpfile.scan_objects(1000) do |batch, size|

--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -73,7 +73,11 @@ module EsDumpRestore
       end
     end
 
-    def create_index(metadata)
+    def create_index(metadata, overrides)
+      if overrides
+        overrides = MultiJson.load(overrides)
+        metadata = deep_merge(metadata, overrides)
+      end
       request(:post, "#{@path_prefix}", :body => MultiJson.dump(metadata))
     end
 
@@ -134,6 +138,17 @@ module EsDumpRestore
         puts "Exception caught issuing HTTP request to #{request_uri}"
         raise e
       end
+    end
+
+    def deep_merge(hash1, hash2)
+      merger = proc { |key, v1, v2|
+        if Hash === v1 && Hash === v2
+          v1.merge(v2, &merger)
+        else
+          v2
+        end
+      }
+      hash1.merge(hash2, &merger)
     end
   end
 end


### PR DESCRIPTION
Add an optional parameter to the `restore` and `restore_alias` commands,
which takes a literal JSON string, and merges that with the
configuration passed when creating the index.

This allows some of the settings or mappings to be overridden when
loading the index, but uses the settings from the dump file by default.

I want to use this when taking a dump from a production system (which
has many shards and replicas) and loading it into a development
environment which has a single node.  For example:

```
    es_dump_restore restore_alias http://localhost:9200 test test-1276512 test_dump.zip \
    '{"settings":{"index":{"number_of_replicas":"0","number_of_shards":"1"}}'
```