### PR TITLE
Make the batch size configurable when restoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ To dump an ElasticSearch index by type to a file:
 
 To restore an index to an ElasticSearch server:
 
-    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES]
+    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE]
 
 To restore an index and set an alias to point to it:
 
-    es_dump_restore restore_alias ELASTIC_SEARCH_SERVER_URL DESTINATION_ALIAS DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES]
+    es_dump_restore restore_alias ELASTIC_SEARCH_SERVER_URL DESTINATION_ALIAS DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE]
 
 This loads the dump into an index named `DESTINATION_INDEX`, and once the load
 is complete sets the alias `DESTINATION_ALIAS` to point to it.  If
@@ -47,6 +47,11 @@ would read the dump file `test_dump.zip`, load it into an index called
 `test-1276512`, then set the alias `test` to point to this index.  The index
 would be set to have no replicas, and only 1 shard, but have all other settings
 from the dump file.
+
+If `BATCH_SIZE` is set for a restore command, it controls the number of
+documents which will be sent to elasticsearch at once.  This defaults to 1000,
+which is normally fine, but if you have particularly complex documents or
+mappings this might need reducing to avoid timeouts.
 
 ## Contributing
 

--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -61,14 +61,14 @@ module EsDumpRestore
     end
 
     desc "restore URL INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index"
-    def restore(url, index_name, filename, overrides=nil)
+    def restore(url, index_name, filename, overrides = nil, batch_size = 1000)
       client = EsClient.new(url, index_name, nil)
 
       Dumpfile.read(filename) do |dumpfile|
         client.create_index(dumpfile.index, overrides)
 
         bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
-        dumpfile.scan_objects(1000) do |batch, size|
+        dumpfile.scan_objects(batch_size.to_i) do |batch, size|
           client.bulk_index batch
           bar.increment!(size) unless options[:noprogressbar]
         end
@@ -76,7 +76,8 @@ module EsDumpRestore
     end
 
     desc "restore_alias URL ALIAS_NAME INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index, and then sets the alias to point at that index, removing any existing indexes pointed at by the alias"
-    def restore_alias(url, alias_name, index_name, filename, overrides=nil)
+    def restore_alias(url, alias_name, index_name, filename, overrides = nil,
+                      batch_size = 1000)
       client = EsClient.new(url, index_name, nil)
       client.check_alias alias_name
 
@@ -84,7 +85,7 @@ module EsDumpRestore
         client.create_index(dumpfile.index, overrides)
 
         bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
-        dumpfile.scan_objects(1000) do |batch, size|
+        dumpfile.scan_objects(batch_size.to_i) do |batch, size|
           client.bulk_index batch
           bar.increment!(size) unless options[:noprogressbar]
         end


### PR DESCRIPTION
Previously, the batch size when loading changes into elasticsearch was
fixed at 1000.  This commit changes the restore commands to take an
optional batch size parameter, as an integer, representing the number of
documents to send at once.

For GOV.UK, we've been experiencing timeouts for some of our more
complex documents, now that we have fairly complex mappings and analysis
chains for these.  This commit allows us to reduce the batch size, and
avoid the timeouts.