### PR TITLE
Improve progressbar options

### DIFF
--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -8,8 +8,8 @@ module EsDumpRestore
   class App < Thor
     class_option :progressbar,
       type: :boolean,
-      default: true,
-      desc: "Whether to show the progress bar."
+      default: $stderr.isatty,
+      desc: "Whether to show the progress bar. Defaults to true if STDERR is a TTY, false otherwise."
 
     option :verbose, :type => :boolean # add some additional output
 

--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -6,8 +6,11 @@ require "multi_json"
 
 module EsDumpRestore
   class App < Thor
-    
-    option :noprogressbar, :type => :boolean # switch for showing progress bar
+    class_option :progressbar,
+      type: :boolean,
+      default: true,
+      desc: "Whether to show the progress bar."
+
     option :verbose, :type => :boolean # add some additional output
 
     desc "dump URL INDEX_NAME FILENAME", "Creates a dumpfile based on the given ElasticSearch index"
@@ -22,13 +25,13 @@ module EsDumpRestore
 
         client.start_scan do |scroll_id, total|
           dumpfile.num_objects = total
-          bar = ProgressBar.new(total) unless options[:noprogressbar]
+          bar = ProgressBar.new(total) if options[:progressbar]
 
           dumpfile.get_objects_output_stream do |out|
             client.each_scroll_hit(scroll_id) do |hit|
               metadata = { index: { _type: hit["_type"], _id: hit["_id"] } }
               out.write("#{MultiJson.dump(metadata)}\n#{MultiJson.dump(hit["_source"])}\n")
-              bar.increment! unless options[:noprogressbar]
+              bar.increment! if options[:progressbar]
             end
           end
         end
@@ -47,13 +50,13 @@ module EsDumpRestore
 
         client.start_scan do |scroll_id, total|
           dumpfile.num_objects = total
-          bar = ProgressBar.new(total) unless options[:noprogressbar]
+          bar = ProgressBar.new(total) if options[:progressbar]
 
           dumpfile.get_objects_output_stream do |out|
             client.each_scroll_hit(scroll_id) do |hit|
               metadata = { index: { _type: hit["_type"], _id: hit["_id"] } }
               out.write("#{MultiJson.dump(metadata)}\n#{MultiJson.dump(hit["_source"])}\n")
-              bar.increment! unless options[:noprogressbar]
+              bar.increment! if options[:progressbar]
             end
           end
         end
@@ -67,10 +70,10 @@ module EsDumpRestore
       Dumpfile.read(filename) do |dumpfile|
         client.create_index(dumpfile.index, overrides)
 
-        bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
+        bar = ProgressBar.new(dumpfile.num_objects) if options[:progressbar]
         dumpfile.scan_objects(batch_size.to_i) do |batch, size|
           client.bulk_index batch
-          bar.increment!(size) unless options[:noprogressbar]
+          bar.increment!(size) if options[:progressbar]
         end
       end
     end
@@ -84,10 +87,10 @@ module EsDumpRestore
       Dumpfile.read(filename) do |dumpfile|
         client.create_index(dumpfile.index, overrides)
 
-        bar = ProgressBar.new(dumpfile.num_objects) unless options[:noprogressbar]
+        bar = ProgressBar.new(dumpfile.num_objects) if options[:progressbar]
         dumpfile.scan_objects(batch_size.to_i) do |batch, size|
           client.bulk_index batch
-          bar.increment!(size) unless options[:noprogressbar]
+          bar.increment!(size) if options[:progressbar]
         end
       end
 


### PR DESCRIPTION
This was previously defined as an option that only applied to the dump
action. Changing this to a `class_option` makes it available to all
actions.

This also inverts the sense of it because Thor automatically adds a
`--no-progressbar` option.  Previously it was adding a `--no-noprogressbar`
option, which is a little confusing with the double-negative.

This updates the default value for the option is to be set based on whether
STDERR is a TTY or not, which is usually what's wanted.

The help output is now:
```
$ bundle exec es_dump_restore --help
Commands:
  es_dump_restore dump URL INDEX_NAME FILENAME                      # Creates a dumpfile bas...
  es_dump_restore dump_type URL INDEX_NAME TYPE FILENAME            # Creates a dumpfile bas...
  es_dump_restore help [COMMAND]                                    # Describe available com...
  es_dump_restore restore URL INDEX_NAME FILENAME                   # Restores a dumpfile in...
  es_dump_restore restore_alias URL ALIAS_NAME INDEX_NAME FILENAME  # Restores a dumpfile in...

Options:
  [--progressbar], [--no-progressbar]  # Whether to show the progress bar.  Defaults to true if STDERR is a TTY, false otherwise.
                                       # Default: true
```

**Note:** This is technically a breaking change because it removes the old `--noprogressbar` option for the dump action.  It should be possible to leave that in place, and have it work alongside the new option at the cost of maintaining that code path.  I'm happy to add that in if its something you think is worth it.