### PR TITLE
_settings path only works at index level, not type level

### DIFF
--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -29,7 +29,7 @@ module EsDumpRestore
     end
 
     def settings
-      data = request(:get, "#{@path_prefix}/_settings")
+      data = request(:get, "#{@index_name}/_settings")
       if data.values.size != 1
         raise "Unexpected response: #{data}"
       end


### PR DESCRIPTION
Previously, we were trying to get _settings based on both the index we
were accessing and the type.  _settings is index specific, and not type
specific, so this URL doesn't exist.

This behavior occurred only when using the dump_type action, all other
actions coincidentally had a functional _settings path to fetch.

This is worth a patch level bump.