### PR TITLE
Retry timed out requests when restoring data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ To dump an ElasticSearch index by type to a file:
 
 To restore an index to an ElasticSearch server:
 
-    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE]
+    es_dump_restore restore ELASTIC_SEARCH_SERVER_URL DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE] [EXCEPTION_RETRIES]
 
 To restore an index and set an alias to point to it:
 
-    es_dump_restore restore_alias ELASTIC_SEARCH_SERVER_URL DESTINATION_ALIAS DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE]
+    es_dump_restore restore_alias ELASTIC_SEARCH_SERVER_URL DESTINATION_ALIAS DESTINATION_INDEX FILENAME_ZIP [SETTING_OVERRIDES] [BATCH_SIZE] [EXCEPTION_RETRIES]
 
 This loads the dump into an index named `DESTINATION_INDEX`, and once the load
 is complete sets the alias `DESTINATION_ALIAS` to point to it.  If
@@ -52,6 +52,9 @@ If `BATCH_SIZE` is set for a restore command, it controls the number of
 documents which will be sent to elasticsearch at once.  This defaults to 1000,
 which is normally fine, but if you have particularly complex documents or
 mappings this might need reducing to avoid timeouts.
+
+If `EXCEPTION_RETRIES` is set to an integer it tells the bulk load process how
+many times is should retry when a timeout is raised. This defaults to 1.
 
 ## Contributing
 

--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -26,8 +26,8 @@ module EsDumpRestore
     end
 
     desc "restore URL INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index"
-    def restore(url, index_name, filename, overrides = nil, batch_size = 1000)
-      client = EsClient.new(url, index_name, nil)
+    def restore(url, index_name, filename, overrides = nil, batch_size = 1000, exception_retries = 1)
+      client = EsClient.new(url, index_name, nil, exception_retries)
 
       Dumpfile.read(filename) do |dumpfile|
         client.create_index(dumpfile.index, overrides)
@@ -42,8 +42,8 @@ module EsDumpRestore
 
     desc "restore_alias URL ALIAS_NAME INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index, and then sets the alias to point at that index, removing any existing indexes pointed at by the alias"
     def restore_alias(url, alias_name, index_name, filename, overrides = nil,
-                      batch_size = 1000)
-      client = EsClient.new(url, index_name, nil)
+                      batch_size = 1000, exception_retries = 1)
+      client = EsClient.new(url, index_name, nil, exception_retries)
       client.check_alias alias_name
 
       Dumpfile.read(filename) do |dumpfile|


### PR DESCRIPTION
Capture timeout error from the HTTPClient library and
retry requests up to the specified limit (default 
to 1).

This is the simplest possible implementation of
retries and does not attempt to give a limit on specific
timeout types, or handle non-timeout related errors.

This is a first attempt to solving: https://github.com/patientslikeme/es_dump_restore/issues/20