### PR TITLE
Ensure exception_retries is always treated as an integer

### DIFF
--- a/lib/es_dump_restore/app.rb
+++ b/lib/es_dump_restore/app.rb
@@ -43,6 +43,7 @@ module EsDumpRestore
     desc "restore_alias URL ALIAS_NAME INDEX_NAME FILENAME", "Restores a dumpfile into the given ElasticSearch index, and then sets the alias to point at that index, removing any existing indexes pointed at by the alias"
     def restore_alias(url, alias_name, index_name, filename, overrides = nil,
                       batch_size = 1000, exception_retries = 1)
+      exception_retries = exception_retries.to_i
       client = EsClient.new(url, index_name, nil, exception_retries)
       client.check_alias alias_name
 


### PR DESCRIPTION
By default, Thor gives you back a string, so the program
crashes with an ArgumentError if this is actually used.

`comparison of Fixnum with String failed (ArgumentError)`

There is a separate issue which is that neither this, the batch size, or settings overrides arguments are reported in the CLI (but it somehow still accepts them).

A cleaner of doing this could be to convert this to a named option, as documented in the Thor getting started guide here: https://github.com/erikhuda/thor/wiki/Getting-Started#options-for-a-task

I haven't done this here because I'm not familiar with how Thor works, plus everything uses positional arguments at the moment, and it doesn't make sense to change the API just for one of them.