### PR TITLE
Expose option to dump to preserve version data

### DIFF
--- a/lib/es_dump_restore/es_client.rb
+++ b/lib/es_dump_restore/es_client.rb
@@ -46,9 +46,9 @@ module EsDumpRestore
 
     def start_scan(&block)
       scroll = request(:get, "#{@path_prefix}/_search",
-        query: { search_type: 'scan', scroll: '10m', size: 500 },
+        query: { search_type: 'scan', scroll: '10m', size: 500, version: true },
         body: MultiJson.dump({
-          fields: ['_source', '_timestamp', '_version', '_routing', '_percolate', '_parent', '_ttl'],
+          fields: ['_source', '_timestamp', '_routing', '_percolate', '_parent', '_ttl'],
           query: { match_all: {} } }
         ))
       total = scroll["hits"]["total"]
@@ -60,9 +60,13 @@ module EsDumpRestore
     def each_scroll_hit(scroll_id, &block)
       done = 0
       loop do
-        batch = request(:get, '_search/scroll', {query: {
-          scroll: '10m', scroll_id: scroll_id
-        }}, [404])
+        batch = request(:get, '_search/scroll', {
+          query: {
+            version: true,
+            scroll: '10m',
+            scroll_id: scroll_id
+          }
+        }, [404])
 
         batch_hits = batch["hits"]
         break if batch_hits.nil?


### PR DESCRIPTION
@nbudin @suzannehamilton

Expose option to dump to preserve version data

The search api expects `version: true` to be set in the params, not as a
requested field.

The bulk api expects both `"_version":<version_number>` and `"version_type": "external"` if
something other than automatic versions are being used.

Since the underlying es apis don't have version preserving as the default option, this
exposes a new `--preserve-versions` option to the dump and dump_type
commands, with a default of false

Doc references:
https://www.elastic.co/guide/en/elasticsearch/reference/6.0/search-request-version.html
https://www.elastic.co/guide/en/elasticsearch/reference/2.4/docs-bulk.html#bulk-versioning

Fixes #25